### PR TITLE
revert a couple of names

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=0.26.1
-stitch_version=0.5.1+build.77
+enigma_version=1.0.0
+stitch_version=0.6.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mappings/net/minecraft/loot/BinomialLootTableRange.mapping
+++ b/mappings/net/minecraft/loot/BinomialLootTableRange.mapping
@@ -1,10 +1,13 @@
-CLASS net/minecraft/class_44 net/minecraft/loot/provider/number/ConstantLootNumberProvider
-	FIELD field_922 value I
-	METHOD <init> (I)V
-		ARG 1 value
-	METHOD method_289 create (I)Lnet/minecraft/class_44;
-		ARG 0 value
-	CLASS class_45 Serializer
+CLASS net/minecraft/class_40 net/minecraft/loot/BinomialLootTableRange
+	FIELD field_917 p F
+	FIELD field_918 n I
+	METHOD <init> (IF)V
+		ARG 1 n
+		ARG 2 p
+	METHOD method_273 create (IF)Lnet/minecraft/class_40;
+		ARG 0 n
+		ARG 1 p
+	CLASS class_41 Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json
 			ARG 2 unused

--- a/mappings/net/minecraft/loot/ConstantLootTableRange.mapping
+++ b/mappings/net/minecraft/loot/ConstantLootTableRange.mapping
@@ -1,13 +1,10 @@
-CLASS net/minecraft/class_40 net/minecraft/loot/provider/number/BinomialLootNumberProvider
-	FIELD field_917 p F
-	FIELD field_918 n I
-	METHOD <init> (IF)V
-		ARG 1 n
-		ARG 2 p
-	METHOD method_273 create (IF)Lnet/minecraft/class_40;
-		ARG 0 n
-		ARG 1 p
-	CLASS class_41 Serializer
+CLASS net/minecraft/class_44 net/minecraft/loot/ConstantLootTableRange
+	FIELD field_922 value I
+	METHOD <init> (I)V
+		ARG 1 value
+	METHOD method_289 create (I)Lnet/minecraft/class_44;
+		ARG 0 value
+	CLASS class_45 Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json
 			ARG 2 unused

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -163,5 +163,3 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 2 centerPos
 	METHOD method_30631 getSpawnAngle ()F
 	METHOD method_31273 getTextStream ()Lnet/minecraft/class_5513;
-	METHOD method_7346 ()V
-		COMMENT Closes the current handled screen and sends a screen closing packet to the client.

--- a/mappings/net/minecraft/world/dimension/DimensionType.mapping
+++ b/mappings/net/minecraft/world/dimension/DimensionType.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 	FIELD field_25613 bedWorks Z
 	FIELD field_25614 respawnAnchorWorks Z
 	FIELD field_25615 hasRaids Z
-	FIELD field_25616 minimumY I
+	FIELD field_25616 logicalHeight I
 	FIELD field_25617 infiniburn Lnet/minecraft/class_2960;
 	FIELD field_26706 coordinateScale D
 	FIELD field_26751 skyProperties Lnet/minecraft/class_2960;
@@ -98,7 +98,7 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 	METHOD method_29956 isBedWorking ()Z
 	METHOD method_29957 isRespawnAnchorWorking ()Z
 	METHOD method_29958 hasRaids ()Z
-	METHOD method_29959 getMinimumY ()I
+	METHOD method_29959 getLogicalHeight ()I
 	METHOD method_29960 hasFixedTime ()Z
 	METHOD method_29961 getInfiniburnBlocks ()Lnet/minecraft/class_3494;
 	METHOD method_31108 equals (Lnet/minecraft/class_2874;)Z


### PR DESCRIPTION
- loot number providers were not a registry in 1.16.5
- "drop invalid mappings" removed the docs in ServerPlayerEntity
- codec name is logical_height in DimensionType